### PR TITLE
Start counting bounties claimed in fleet carriers.

### DIFF
--- a/tests/test_event_processors.py
+++ b/tests/test_event_processors.py
@@ -158,46 +158,43 @@ def test_location_sequence(location_events: Tuple, expected_station: Station):
             [RedeemVoucherEventSummary("", {"CPD-59 314 Imperial Society"}, {"The Fuel Rats Mischief"}, "CombatBond", 1177365)]
         ),
         (
-            StarSystem("", 1000, ("The Fuel Rats Mischief",)),
-            Station("", 1000, "The Fuel Rats Mischief"),
-            {"timestamp":"2020-10-18T11:23:57Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1127126, "Faction":"HR 1597 & Co", "BrokerPercentage":25.000000 },
-            [RedeemVoucherEventSummary("", {"HR 1597 & Co"}, set(), "CombatBond", 1502835)]
-        ),
-        (
+            # Interstellar factors
             StarSystem("", 1000, ("The Fuel Rats Mischief",)),
             Station("", 1000, "The Fuel Rats Mischief"),
             {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":46026, "Faction":"", "BrokerPercentage":25.000000 },
-            [RedeemVoucherEventSummary("", {""}, set(), "CombatBond", 61368)]
+            []
         ),
         (
+            # Fleet carrier redemption office
             StarSystem("", 1000, ("The Fuel Rats Mischief", "HR 1597 & Co")),
             Station("", 1000, "The Fuel Rats Mischief"),
             {"timestamp":"2020-10-18T11:23:57Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1127126, "Faction":"HR 1597 & Co", "BrokerPercentage":25.000000 },
             [RedeemVoucherEventSummary("", {"HR 1597 & Co"}, {"The Fuel Rats Mischief"}, "CombatBond", 1502835)]
         ),
+        # Redemption office percentages; this should not happen in game.
         (
-            StarSystem("", 1000, ("The Fuel Rats Mischief",)),
+            StarSystem("", 1000, ("The Fuel Rats Mischief", "HR 1597 & Co")),
             Station("", 1000, "The Fuel Rats Mischief"),
-            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"", "BrokerPercentage":0.000000 },
-            [RedeemVoucherEventSummary("", {""}, set(), "CombatBond", 1000)]
+            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"HR 1597 & Co", "BrokerPercentage":0.000000 },
+            [RedeemVoucherEventSummary("", {"HR 1597 & Co"}, {"The Fuel Rats Mischief"}, "CombatBond", 1000)]
         ),
         (
-            StarSystem("", 1000, ("The Fuel Rats Mischief",)),
+            StarSystem("", 1000, ("The Fuel Rats Mischief", "HR 1597 & Co")),
             Station("", 1000, "The Fuel Rats Mischief"),
-            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"", "BrokerPercentage":1.000000 },
-            [RedeemVoucherEventSummary("", {""}, set(), "CombatBond", 1010)]
+            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"HR 1597 & Co", "BrokerPercentage":1.000000 },
+            [RedeemVoucherEventSummary("", {"HR 1597 & Co"}, {"The Fuel Rats Mischief"}, "CombatBond", 1010)]
         ),
         (
-            StarSystem("", 1000, ("The Fuel Rats Mischief",)),
+            StarSystem("", 1000, ("The Fuel Rats Mischief", "HR 1597 & Co")),
             Station("", 1000, "The Fuel Rats Mischief"),
-            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"", "BrokerPercentage":99.000000 },
-            [RedeemVoucherEventSummary("", {""}, set(), "CombatBond", 100000)]
+            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"HR 1597 & Co", "BrokerPercentage":99.000000 },
+            [RedeemVoucherEventSummary("", {"HR 1597 & Co"}, {"The Fuel Rats Mischief"}, "CombatBond", 100000)]
         ),
         (
-            StarSystem("", 1000, ("The Fuel Rats Mischief",)),
+            StarSystem("", 1000, ("The Fuel Rats Mischief", "HR 1597 & Co")),
             Station("", 1000, "The Fuel Rats Mischief"),
-            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"", "BrokerPercentage":100.000000 },
-            [RedeemVoucherEventSummary("", {""}, set(), "CombatBond", 1000)]
+            {"timestamp":"2020-07-17T15:21:20Z", "event":"RedeemVoucher", "Type":"CombatBond", "Amount":1000, "Faction":"HR 1597 & Co", "BrokerPercentage":100.000000 },
+            [RedeemVoucherEventSummary("", {"HR 1597 & Co"}, {"The Fuel Rats Mischief"}, "CombatBond", 1000)]
         ),
 
         # Scannable (Not sure what this is)

--- a/tests/test_event_processors.py
+++ b/tests/test_event_processors.py
@@ -119,16 +119,18 @@ def test_location_sequence(location_events: Tuple, expected_station: Station):
             [RedeemVoucherEventSummary("Fuelum", {"Findja Empire Assembly"}, {"The Fuel Rats Mischief"}, "bounty", 25490)]
         ),
         (
+            # Interstellar factors
             StarSystem("Findja", 1000, ("The Fuel Rats Mischief",)),
             Station("Station", 1000, "The Fuel Rats Mischief"),
             {"timestamp": "2020-05-09T03:42:31Z", "event": "RedeemVoucher", "Type": "bounty", "Amount": 13338, "Factions":[ { "Faction":"", "Amount":13338 } ], "BrokerPercentage": 25.000000 },
             []
         ),
         (
+            # Fleet carrier redemption office
             StarSystem("CPD-59 314", 1000, ("The Fuel Rats Mischief", "CPD-59 314 Imperial Society")),
             Station("Station", 1000, "The Fuel Rats Mischief"),
             {"timestamp": "2020-10-15T14:45:16Z", "event": "RedeemVoucher", "Type": "bounty", "Amount": 1779467, "Factions": [ { "Faction": "CPD-59 314 Imperial Society", "Amount": 1779467 } ], "BrokerPercentage":25.000000 },
-            []
+            [RedeemVoucherEventSummary("CPD-59 314", {"CPD-59 314 Imperial Society"}, {"The Fuel Rats Mischief"}, "bounty", 1779467)]
         ),
         (
             StarSystem("Fuelum", 1000, ("The Fuel Rats Mischief", "Rabh Empire Pact", "Kacomam Empire Group", "Trumuye Emperor's Grace", "EDA Kunti League")),

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -24,7 +24,7 @@ def test_tracker_init():
             {"HR 1597 & Co"}, 
             "Journal.201019220908.01.log", 
             ("HR 1597 - ANTI HR 1597 & Co\n"
-            "1,852,906 CR of Bounty Vouchers\n"
+            "1,916,227 CR of Bounty Vouchers\n"
             "\n"
             "HR 1597 - PRO HR 1597 & Co\n"
             "1 INF++ mission(s)\n"
@@ -301,7 +301,10 @@ def test_tracker_init():
             "Journal.210817213224.01.log",
             ("Naualam - ANTI Extra Corporation\n"
             "5 INF+ mission(s)\n"
-            "1 INF++ mission(s)")    
+            "1 INF++ mission(s)\n"
+            "\n"
+            "Naualam - PRO Extra Corporation\n"
+            "1,278,672 CR of Bounty Vouchers")
         ),
         (
             {"EDA Kunti League"},


### PR DESCRIPTION

Bounties claimed in fleet carriers count for influence, if cashed in a system with minor faction presence. As a rule, if the minor faction name appears in the log, the redeem counts for influence (or conflict).

This change counts bounties if the minor faction name is present, ignoring the existence of a broker fee. This effectively considers fleet carriers, while ignoring interstellar factors (IF redeems never list a faction name).

This approach is extended to bonds for uniformity, without any change in the expected output (had to adjusts some tests though).